### PR TITLE
add note to build from source on macOS

### DIFF
--- a/docs/Get-Started/Build-From-Source.md
+++ b/docs/Get-Started/Build-From-Source.md
@@ -27,6 +27,17 @@ After cloning, go to the `quorum-key-manager` directory:
 cd quorum-key-manager
 ```
 
+!!! note
+
+    If using macOS, open `Makefile` and remove `@GOOS=linux GOARCH=amd64` under `gobuild`:
+
+    ```
+    ...
+    gobuild:
+        go build -o ./build/bin/key-manager
+    ...
+    ```
+
 Install the project vendors:
 
 ```bash


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consenssys/doc.web3signer/blob/master/CONTRIBUTING.md -->

## Pull Request Description

Add note that mac users must modify `Makefile` when building from source.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<GitHub issue number> -->
<!-- Example: "fixes #123" -->

fixes #26 
