### PR TITLE
Fix env var name for DB_TLS_SSLMODE

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -325,7 +325,7 @@ Database port. The default is `5432`.
 # Environment variable
 
 ```bash
-DB_SSLMODE="require"
+DB_TLS_SSLMODE="require"
 ```
 
 <!--/tabs-->


### PR DESCRIPTION
Fix environment variable name for `DB_TLS_SSLMODE`. The command line option `db-sslmode` appears to be differently named than the corresponding environment variable `DB_TLS_SSLMODE`. See https://github.com/ConsenSys/quorum-key-manager/blob/d509f52d9ab3d6476327415a6d276f4e570b50e2/cmd/flags/postgres.go#L182.

Fixes #62 